### PR TITLE
fix(extension): specify activation event

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"vscode": "^1.48.0"
 	},
 	"activationEvents": [
-		"*"
+		"onLanguage:python"
 	],
 	"main": "./dist/extension",
 	"contributes": {


### PR DESCRIPTION
I'm primarily a JS/TS developer and even if your extension doesn't bother me in regular development (as it just doesn't intend to work there :) ), I think it shouldn't be activated on languages other than python.

Thanks for developing a great extension!